### PR TITLE
Refactored cloud-readiness/embedded-cache-libraries.windup.xml

### DIFF
--- a/rules/rules-overridden-azure/technology-usage/embedded-cache-libraries.windup.xml
+++ b/rules/rules-overridden-azure/technology-usage/embedded-cache-libraries.windup.xml
@@ -25,11 +25,11 @@
                 <file filename="{*}redis{*}.jar"/>
             </when>
             <perform>
-                <classification title="Redis Cache library" category-id="information" effort="0">
-                    <description>
+                <hint title="Redis Cache library" category-id="information" effort="0">
+                    <message>
                         Blah blah blah.
-                    </description>
-                </classification>
+                    </message>
+                </hint>
                 <technology-tag level="INFORMATIONAL">Redis</technology-tag>
             </perform>
         </rule>

--- a/rules/rules-reviewed/cloud-readiness/embedded-cache.windup.xml
+++ b/rules/rules-reviewed/cloud-readiness/embedded-cache.windup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset id="embedded-cache-libraries" xmlns="http://windup.jboss.org/schema/jboss-ruleset" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<ruleset id="embedded-cache" xmlns="http://windup.jboss.org/schema/jboss-ruleset" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
     <metadata>
         <description>
@@ -10,10 +10,9 @@
             <addon id="org.jboss.windup.rules,windup-rules-java,3.0.0.Final" />
         </dependencies>
         <targetTechnology id="cloud-readiness"/>
-        <overrideRules>true</overrideRules>
     </metadata>
     <rules>
-        <rule id="embedded-cache-libraries-01000">
+        <rule id="embedded-cache-01000">
             <when>
                 <graph-query discriminator="JarArchiveModel">
                     <property name="fileName" searchType="regex">.*ehcache.*\.jar$</property>
@@ -32,7 +31,7 @@
                 <technology-tag level="INFORMATIONAL">Ehcache</technology-tag>
             </perform>
         </rule>
-        <rule id="embedded-cache-libraries-02000">
+        <rule id="embedded-cache-02000">
             <when>
                 <graph-query discriminator="JarArchiveModel">
                     <property name="fileName" searchType="regex">.*coherence.*\.jar$</property>
@@ -51,7 +50,7 @@
                 <technology-tag level="INFORMATIONAL">Coherence</technology-tag>
             </perform>
         </rule>
-        <rule id="embedded-cache-libraries-03000">
+        <rule id="embedded-cache-03000">
             <when>
                 <graph-query discriminator="JarArchiveModel">
                     <property name="fileName" searchType="regex">.*commons-jcs.*\.jar$</property>
@@ -70,7 +69,7 @@
                 <technology-tag level="INFORMATIONAL">Apache Commons JCS</technology-tag>
             </perform>
         </rule>
-        <rule id="embedded-cache-libraries-04000">
+        <rule id="embedded-cache-04000">
             <when>
                 <graph-query discriminator="JarArchiveModel">
                     <property name="fileName" searchType="regex">.*dynacache.*\.jar$</property>
@@ -89,7 +88,7 @@
                 <technology-tag level="INFORMATIONAL">Dynacache</technology-tag>
             </perform>
         </rule>
-        <rule id="embedded-cache-libraries-05000">
+        <rule id="embedded-cache-05000">
             <when>
                 <graph-query discriminator="JarArchiveModel">
                     <property name="fileName" searchType="regex">.*cache-api.*\.jar$</property>
@@ -108,7 +107,7 @@
                 <technology-tag level="INFORMATIONAL">Cache API</technology-tag>
             </perform>
         </rule>
-        <rule id="embedded-cache-libraries-06000">
+        <rule id="embedded-cache-06000">
             <when>
                 <graph-query discriminator="JarArchiveModel">
                     <property name="fileName" searchType="regex">.*hazelcast.*\.jar$</property>
@@ -127,7 +126,7 @@
                 <technology-tag level="INFORMATIONAL">Hazelcast</technology-tag>
             </perform>
         </rule>
-        <rule id="embedded-cache-libraries-07000">
+        <rule id="embedded-cache-07000">
             <when>
                 <graph-query discriminator="JarArchiveModel">
                     <property name="fileName" searchType="regex">.*ignite.*\.jar$</property>
@@ -146,7 +145,7 @@
                 <technology-tag level="INFORMATIONAL">Apache Ignite</technology-tag>
             </perform>
         </rule>
-        <rule id="embedded-cache-libraries-08000">
+        <rule id="embedded-cache-08000">
             <when>
                 <graph-query discriminator="JarArchiveModel">
                     <property name="fileName" searchType="regex">.*infinispan.*\.jar$</property>
@@ -165,7 +164,7 @@
                 <technology-tag level="INFORMATIONAL">Infinispan</technology-tag>
             </perform>
         </rule>
-        <rule id="embedded-cache-libraries-09000">
+        <rule id="embedded-cache-09000">
             <when>
                 <graph-query discriminator="JarArchiveModel">
                     <property name="fileName" searchType="regex">.*jbosscache.*\.jar$</property>
@@ -184,7 +183,7 @@
                 <technology-tag level="INFORMATIONAL">JBoss Cache</technology-tag>
             </perform>
         </rule>
-        <rule id="embedded-cache-libraries-10000">
+        <rule id="embedded-cache-10000">
             <when>
                 <graph-query discriminator="JarArchiveModel">
                     <property name="fileName" searchType="regex">.*jcache.*\.jar$</property>
@@ -203,7 +202,7 @@
                 <technology-tag level="INFORMATIONAL">JCache</technology-tag>
             </perform>
         </rule>
-        <rule id="embedded-cache-libraries-11000">
+        <rule id="embedded-cache-11000">
             <when>
                 <graph-query discriminator="JarArchiveModel">
                     <property name="fileName" searchType="regex">.*memcached.*\.jar$</property>
@@ -222,7 +221,7 @@
                 <technology-tag level="INFORMATIONAL">Memcached client</technology-tag>
             </perform>
         </rule>
-        <rule id="embedded-cache-libraries-12000">
+        <rule id="embedded-cache-12000">
             <when>
                 <graph-query discriminator="JarArchiveModel">
                     <property name="fileName" searchType="regex">.*oscache.*\.jar$</property>
@@ -241,7 +240,7 @@
                 <technology-tag level="INFORMATIONAL">Oscache</technology-tag>
             </perform>
         </rule>
-        <rule id="embedded-cache-libraries-13000">
+        <rule id="embedded-cache-13000">
             <when>
                 <graph-query discriminator="JarArchiveModel">
                     <property name="fileName" searchType="regex">.*shiftone.*\.jar$</property>
@@ -260,7 +259,7 @@
                 <technology-tag level="INFORMATIONAL">ShiftOne</technology-tag>
             </perform>
         </rule>
-        <rule id="embedded-cache-libraries-14000">
+        <rule id="embedded-cache-14000">
             <when>
                 <graph-query discriminator="JarArchiveModel">
                     <property name="fileName" searchType="regex">.*swarmcache.*\.jar$</property>
@@ -279,7 +278,7 @@
                 <technology-tag level="INFORMATIONAL">SwarmCache</technology-tag>
             </perform>
         </rule>
-        <rule id="embedded-cache-libraries-15000">
+        <rule id="embedded-cache-15000">
             <when>
                 <or>
                     <dependency groupId="org.springframework.boot" artifactId="spring-boot-starter-cache"/>
@@ -301,7 +300,7 @@
                 <technology-tag level="INFORMATIONAL">Spring Boot Cache</technology-tag>
             </perform>
         </rule>
-        <rule id="embedded-cache-libraries-16000">
+        <rule id="embedded-cache-16000">
             <when>
                 <file filename="{*}redis{*}.jar"/>
             </when>

--- a/rules/rules-reviewed/cloud-readiness/tests/embedded-cache.windup.test.xml
+++ b/rules/rules-reviewed/cloud-readiness/tests/embedded-cache.windup.test.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0"?>
-<ruletest id="embedded-cache-libraries-cloud-readiness-test" xmlns="http://windup.jboss.org/schema/jboss-ruleset" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<ruletest id="embedded-cache-test" xmlns="http://windup.jboss.org/schema/jboss-ruleset" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
     <testDataPath>../../technology-usage/tests/data/embedded-framework/embedded-cache-libraries</testDataPath>
-    <rulePath>../../technology-usage/embedded-cache-libraries.windup.xml</rulePath>
-    <rulePath>../embedded-cache-libraries.windup.xml</rulePath>
-    <target>cloud-readiness</target>
+    <rulePath>../embedded-cache.windup.xml</rulePath>
     <ruleset>
         <rules>
-            <rule id="embedded-cache-libraries-cloud-readiness-test-01000">
+            <rule id="embedded-cache-test-01000">
                 <when>
                     <not>
                         <classification-exists classification="Caching - Ehcache embedded library"/>
@@ -17,7 +15,7 @@
                     <fail message="Ehcache classification not found!" />
                 </perform>
             </rule>
-            <rule id="embedded-cache-libraries-cloud-readiness-test-02000">
+            <rule id="embedded-cache-test-02000">
                 <when>
                     <not>
                         <classification-exists classification="Caching - Coherence embedded library"/>
@@ -27,7 +25,7 @@
                     <fail message="Coherence classification not found!" />
                 </perform>
             </rule>
-            <rule id="embedded-cache-libraries-cloud-readiness-test-03000">
+            <rule id="embedded-cache-test-03000">
                 <when>
                     <not>
                         <classification-exists classification="Caching - Apache Commons JCS embedded library"/>
@@ -37,7 +35,7 @@
                     <fail message="Apache Commons JCS classification not found!" />
                 </perform>
             </rule>
-            <rule id="embedded-cache-libraries-cloud-readiness-test-04000">
+            <rule id="embedded-cache-test-04000">
                 <when>
                     <not>
                         <classification-exists classification="Caching - Dynacache embedded library"/>
@@ -47,7 +45,7 @@
                     <fail message="Dynacache classification not found!" />
                 </perform>
             </rule>
-            <rule id="embedded-cache-libraries-cloud-readiness-test-05000">
+            <rule id="embedded-cache-test-05000">
                 <when>
                     <not>
                         <classification-exists classification="Caching - Embedded library"/>
@@ -57,7 +55,7 @@
                     <fail message="Generic Caching Jar Classification not found!" />
                 </perform>
             </rule>
-            <rule id="embedded-cache-libraries-cloud-readiness-test-06000">
+            <rule id="embedded-cache-test-06000">
                 <when>
                     <not>
                         <classification-exists classification="Caching - Hazelcast embedded library"/>
@@ -67,7 +65,7 @@
                     <fail message="Hazelcast classification not found!" />
                 </perform>
             </rule>
-            <rule id="embedded-cache-libraries-cloud-readiness-test-07000">
+            <rule id="embedded-cache-test-07000">
                 <when>
                     <not>
                         <classification-exists classification="Caching - Apache Ignite embedded library"/>
@@ -77,7 +75,7 @@
                     <fail message="Apache Ignite classification not found!" />
                 </perform>
             </rule>
-            <rule id="embedded-cache-libraries-cloud-readiness-test-08000">
+            <rule id="embedded-cache-test-08000">
                 <when>
                     <not>
                         <classification-exists classification="Caching - Infinispan embedded library"/>
@@ -87,7 +85,7 @@
                     <fail message="Infinispan classification not found!" />
                 </perform>
             </rule>
-            <rule id="embedded-cache-libraries-cloud-readiness-test-09000">
+            <rule id="embedded-cache-test-09000">
                 <when>
                     <not>
                         <classification-exists classification="Caching - JBoss Cache embedded library"/>
@@ -97,7 +95,7 @@
                     <fail message="JBoss Cache classification not found!" />
                 </perform>
             </rule>
-            <rule id="embedded-cache-libraries-cloud-readiness-test-10000">
+            <rule id="embedded-cache-test-10000">
                 <when>
                     <not>
                         <classification-exists classification="Caching - JCache embedded library"/>
@@ -107,7 +105,7 @@
                     <fail message="JCache classification not found!" />
                 </perform>
             </rule>
-            <rule id="embedded-cache-libraries-cloud-readiness-test-11000">
+            <rule id="embedded-cache-test-11000">
                 <when>
                     <not>
                         <classification-exists classification="Caching - Memcached client embedded library"/>
@@ -117,7 +115,7 @@
                     <fail message="Memcached client classification not found!" />
                 </perform>
             </rule>
-            <rule id="embedded-cache-libraries-cloud-readiness-test-12000">
+            <rule id="embedded-cache-test-12000">
                 <when>
                     <not>
                         <classification-exists classification="Caching - Oscache embedded library"/>
@@ -127,7 +125,7 @@
                     <fail message="Oscache classification not found!" />
                 </perform>
             </rule>
-            <rule id="embedded-cache-libraries-cloud-readiness-test-13000">
+            <rule id="embedded-cache-test-13000">
                 <when>
                     <not>
                         <classification-exists classification="Caching - ShiftOne \(Java Object Cache\) embedded library"/>
@@ -137,7 +135,7 @@
                     <fail message="ShiftOne classification not found!" />
                 </perform>
             </rule>
-            <rule id="embedded-cache-libraries-cloud-readiness-test-14000">
+            <rule id="embedded-cache-test-14000">
                 <when>
                     <not>
                         <classification-exists classification="Caching - SwarmCache embedded library"/>
@@ -147,7 +145,7 @@
                     <fail message="SwarmCache classification not found!" />
                 </perform>
             </rule>
-            <rule id="embedded-cache-libraries-cloud-readiness-test-15000">
+            <rule id="embedded-cache-test-15000">
                 <when>
                     <not>
                         <classification-exists classification="Caching - Spring Boot Cache library"/>
@@ -157,7 +155,7 @@
                     <fail message="Spring Boot Cache classification not found!" />
                 </perform>
             </rule>
-            <rule id="embedded-cache-libraries-cloud-readiness-test-16000">
+            <rule id="embedded-cache-test-16000">
                 <when>
                     <not>
                         <classification-exists classification="Caching - Redis Cache library"/>


### PR DESCRIPTION
Refers to https://github.com/Azure/windup-rulesets/pull/93
Multi-overriding can not work with (current) Windup and changing this would require some design to properly design a solution which, if any really, would have quite some limitations.

Another approach I discussed with @PhilipCattanach has been about the current situation where the cloud-readiness/embedded-cache-libraries.windup.xml ruleset is, without any real demand, an overriding ruleset.

So in this PR I shared a solution to your issue:

- cloud-readiness/embedded-cache-libraries.windup.xml has been refactored to be a "proper" ruleset
- rules-overridden-azure/technology-usage/embedded-cache-libraries.windup.xml has been fixed to meet the expected outcome in the test